### PR TITLE
Update to the version 1.13.0 of kubectl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM alpine:3.6
 
-MAINTAINER Sergii Nuzhdin <ipaq.lw@gmail.com@gmail.com>
+LABEL MAINTAINER="Sergii Nuzhdin <ipaq.lw@gmail.com@gmail.com>"
 
-ENV KUBE_LATEST_VERSION="v1.10.0"
+ENV KUBE_LATEST_VERSION="v1.13.0"
 
 RUN apk add --update ca-certificates \
- && apk add --update -t deps curl \
- && apk add --update gettext \
- && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
- && chmod +x /usr/local/bin/kubectl \
- && apk del --purge deps \
- && rm /var/cache/apk/*
+    && apk add --update -t deps curl \
+    && apk add --update gettext \
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && apk del --purge deps \
+    && rm /var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # kubectl-deployer-docker
+
 Alpine based image with kubectl and gettext used in gitlab-ci build steps.
 
 http://blog.lwolf.org/post/continuous-deployment-to-kubernetes-from-gitlab-ci/
 
 docker image location: https://hub.docker.com/r/lwolf/kubectl_deployer/
 
-|Tag       | Alpine |   Kubectl    |
-|:--------:|:------:|:------------:|
-|latest    |3.6     |1.10.0        |
-|1.10.0    |3.6     |1.10.0        |
-|1.8.9     |3.6     |1.8.9         |
-|0.4       |3.6     |1.6.4         |
-|0.3       |3.4     |1.6.4         |
-|0.2       |3.4     |1.5.2         |
-
+|  Tag   | Alpine | Kubectl |
+| :----: | :----: | :-----: |
+| latest |  3.6   | 1.13.0  |
+| 1.13.0 |  3.6   | 1.13.0  |
+| 1.10.0 |  3.6   | 1.10.0  |
+| 1.8.9  |  3.6   |  1.8.9  |
+|  0.4   |  3.6   |  1.6.4  |
+|  0.3   |  3.4   |  1.6.4  |
+|  0.2   |  3.4   |  1.5.2  |


### PR DESCRIPTION
Update to Kubectl 1.13.0 to support new enhancement features available on the kubernetes platform.

Please update the readme of your docker hub too.